### PR TITLE
Add support for updating Az modules with parameter AzureModuleClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ Import this runbook into your Automation account, and [start](https://docs.micro
   run when the **Update Azure Modules** button is pushed or when this runbook is invoked directly
   via ARM API for this Automation account. If this is not what you want, specify a different name
   when importing this runbook.
-* Only **Azure** and **AzureRM.\*** modules are currently supported. The new [Azure PowerShell Az modules](https://docs.microsoft.com/powershell/azure/new-azureps-module-az) are not supported yet.
-  Avoid starting this runbook on Automation accounts that contain Az modules.
+* **Azure** and **AzureRM.\*** modules are currently supported by default.
+* The new [Azure PowerShell Az modules](https://docs.microsoft.com/powershell/azure/new-azureps-module-az)
+  are also supported. You **must** supply the `AzureModuleClass` runbook parameter with `Az` if
+  your runbooks use only Az modules to avoid conflicts. More information can be found in the
+  [Microsoft Docs](https://docs.microsoft.com/en-us/azure/automation/az-modules) and
+  issue [#5](https://github.com/microsoft/AzureAutomation-Account-Modules-Update/issues/5).
+  Avoid starting this runbook on Automation accounts that contain both AzureRM and Az modules.
 * Before starting this runbook, make sure your Automation account has an [Azure Run As account credential](https://docs.microsoft.com/azure/automation/manage-runas-account) created.
 * You can use this code as a regular PowerShell script instead of a runbook: just login to Azure
   using the [Connect-AzureRmAccount](https://docs.microsoft.com/powershell/module/azurerm.profile/connect-azurermaccount)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Import this runbook into your Automation account, and [start](https://docs.micro
 * The new [Azure PowerShell Az modules](https://docs.microsoft.com/powershell/azure/new-azureps-module-az)
   are also supported. You **must** supply the `AzureModuleClass` runbook parameter with `Az` if
   your runbooks use only Az modules to avoid conflicts. More information can be found in the
-  [Microsoft Docs](https://docs.microsoft.com/en-us/azure/automation/az-modules) and
+  [Microsoft Docs](https://docs.microsoft.com/azure/automation/az-modules) and
   issue [#5](https://github.com/microsoft/AzureAutomation-Account-Modules-Update/issues/5).
   Avoid starting this runbook on Automation accounts that contain both AzureRM and Az modules.
 * Before starting this runbook, make sure your Automation account has an [Azure Run As account credential](https://docs.microsoft.com/azure/automation/manage-runas-account) created.

--- a/Tests/Update-AutomationAzureModulesForAccount.Tests.ps1
+++ b/Tests/Update-AutomationAzureModulesForAccount.Tests.ps1
@@ -77,7 +77,7 @@ Describe 'Update-AutomationAzureModulesForAccount runbook' {
     Context 'No overridden module versions' {
         Mock Get-AzureRmAutomationModule {
             @{
-                Name = 'FakeAzureModule'
+                Name = 'AzureRM.FakeAzureModule'
                 Version = '1.0.0'
                 ProvisioningState = 'Succeeded'
             }
@@ -154,10 +154,10 @@ Describe 'Update-AutomationAzureModulesForAccount runbook' {
         } -Verifiable
 
         Mock Invoke-RestMethod -ParameterFilter {
-            $Uri -match '%27FakeAzureModule%27'
+            $Uri -match '%27AzureRM.FakeAzureModule%27'
         } -MockWith {
             $Method | Should be 'Get' > $null
-            Assert-CorrectSearchUri -Uri $Uri -ModuleName FakeAzureModule
+            Assert-CorrectSearchUri -Uri $Uri -ModuleName AzureRM.FakeAzureModule
             
             @{
                 id = 'fake FakeAzureModule search result id'
@@ -181,21 +181,21 @@ Describe 'Update-AutomationAzureModulesForAccount runbook' {
         } -Verifiable
 
         Mock Invoke-WebRequest -ParameterFilter {
-            $Uri -match 'https://www.powershellgallery.com/api/v2/package/FakeAzureModule'
+            $Uri -match 'https://www.powershellgallery.com/api/v2/package/AzureRM.FakeAzureModule'
         } -MockWith {
-            $Uri | Should be 'https://www.powershellgallery.com/api/v2/package/FakeAzureModule' > $null
+            $Uri | Should be 'https://www.powershellgallery.com/api/v2/package/AzureRM.FakeAzureModule' > $null
 
             @{
                 Headers = @{
-                    Location = 'Fake/FakeAzureModule/Content/Location.nupkg'
+                    Location = 'Fake/AzureRM.FakeAzureModule/Content/Location.nupkg'
                 }
             }
         } -Verifiable
 
         Mock New-AzureRmAutomationModule -ParameterFilter {
-            $Name -eq 'FakeAzureModule'
+            $Name -eq 'AzureRM.FakeAzureModule'
         } -MockWith {
-            $ContentLink | Should be 'Fake/FakeAzureModule/Content/Location.nupkg' > $null
+            $ContentLink | Should be 'Fake/AzureRM.FakeAzureModule/Content/Location.nupkg' > $null
         } -Verifiable
 
         Invoke-Update-AutomationAzureModulesForAccount -OptionalParameters @{
@@ -207,7 +207,7 @@ Describe 'Update-AutomationAzureModulesForAccount runbook' {
         }
 
         It 'Updates fake Azure module' {
-            Assert-MockCalled New-AzureRmAutomationModule -ParameterFilter { $Name -eq 'FakeAzureModule' } -Times 1 -Exactly
+            Assert-MockCalled New-AzureRmAutomationModule -ParameterFilter { $Name -eq 'AzureRM.FakeAzureModule' } -Times 1 -Exactly
         }
 
         Assert-VerifiableMock
@@ -216,7 +216,7 @@ Describe 'Update-AutomationAzureModulesForAccount runbook' {
     Context 'With overridden module versions' {
         Mock Get-AzureRmAutomationModule {
             @{
-                Name = 'FakeAzureModule'
+                Name = 'AzureRM.FakeAzureModule'
                 Version = '1.0.0'
                 ProvisioningState = 'Succeeded'
             }
@@ -295,10 +295,10 @@ Describe 'Update-AutomationAzureModulesForAccount runbook' {
         } -Verifiable
 
         Mock Invoke-RestMethod -ParameterFilter {
-            $Uri -match '%27FakeAzureModule%27'
+            $Uri -match '%27AzureRM.FakeAzureModule%27'
         } -MockWith {
             $Method | Should be 'Get' > $null
-            Assert-CorrectSearchUri -Uri $Uri -ModuleName FakeAzureModule
+            Assert-CorrectSearchUri -Uri $Uri -ModuleName AzureRM.FakeAzureModule
             
             @{
                 id = 'fake FakeAzureModule search result id'
@@ -322,21 +322,21 @@ Describe 'Update-AutomationAzureModulesForAccount runbook' {
         } -Verifiable
 
         Mock Invoke-WebRequest -ParameterFilter {
-            $Uri -match 'https://www.powershellgallery.com/api/v2/package/FakeAzureModule'
+            $Uri -match 'https://www.powershellgallery.com/api/v2/package/AzureRM.FakeAzureModule'
         } -MockWith {
-            $Uri | Should be 'https://www.powershellgallery.com/api/v2/package/FakeAzureModule' > $null
+            $Uri | Should be 'https://www.powershellgallery.com/api/v2/package/AzureRM.FakeAzureModule' > $null
 
             @{
                 Headers = @{
-                    Location = 'Fake/FakeAzureModule/Content/Location.nupkg'
+                    Location = 'Fake/AzureRM.FakeAzureModule/Content/Location.nupkg'
                 }
             }
         } -Verifiable
 
         Mock New-AzureRmAutomationModule -ParameterFilter {
-            $Name -eq 'FakeAzureModule'
+            $Name -eq 'AzureRM.FakeAzureModule'
         } -MockWith {
-            $ContentLink | Should be 'Fake/FakeAzureModule/Content/Location.nupkg' > $null
+            $ContentLink | Should be 'Fake/AzureRM.FakeAzureModule/Content/Location.nupkg' > $null
         } -Verifiable
 
         Invoke-Update-AutomationAzureModulesForAccount -OptionalParameters @{
@@ -350,7 +350,7 @@ Describe 'Update-AutomationAzureModulesForAccount runbook' {
         }
 
         It 'Updates fake Azure module' {
-            Assert-MockCalled New-AzureRmAutomationModule -ParameterFilter { $Name -eq 'FakeAzureModule' } -Times 1 -Exactly
+            Assert-MockCalled New-AzureRmAutomationModule -ParameterFilter { $Name -eq 'AzureRM.FakeAzureModule' } -Times 1 -Exactly
         }
 
         Assert-VerifiableMock
@@ -407,31 +407,31 @@ Describe 'Update-AutomationAzureModulesForAccount runbook' {
 
         Mock Get-AzureRmAutomationModule {
             @{
-                Name = 'FakeAzureModule'
+                Name = 'AzureRM.FakeAzureModule'
                 Version = '1.0.0'
                 ProvisioningState = 'Succeeded'
             }
         } -Verifiable
 
         Mock Invoke-RestMethod -ParameterFilter {
-            $Uri -match '%27FakeAzureModule%27'
+            $Uri -match '%27AzureRM.FakeAzureModule%27'
         } -MockWith {
             $Method | Should be 'Get' > $null
-            Assert-CorrectSearchUri -Uri $Uri -ModuleName FakeAzureModule -Filter "Version%20eq%20'2.0.0'"
+            Assert-CorrectSearchUri -Uri $Uri -ModuleName AzureRM.FakeAzureModule -Filter "Version%20eq%20'2.0.0'"
             
             @{
                 id = 'fake FakeAzureModule search result id 1'
-                title = @{ InnerText = 'FakeAzureModule.Different' }
+                title = @{ InnerText = 'AzureRM.FakeAzureModule.Different' }
             }
             
             @{
                 id = 'fake FakeAzureModule search result id 2'
-                title = @{ InnerText = 'FakeAzureModule' }
+                title = @{ InnerText = 'AzureRM.FakeAzureModule' }
             }
             
             @{
                 id = 'fake FakeAzureModule search result id 3'
-                title = @{ InnerText = 'FakeAzureModule.AnotherOne' }
+                title = @{ InnerText = 'AzureRM.FakeAzureModule.AnotherOne' }
             }
         } -Verifiable
 
@@ -452,31 +452,31 @@ Describe 'Update-AutomationAzureModulesForAccount runbook' {
         } -Verifiable
 
         Mock Invoke-WebRequest -ParameterFilter {
-            $Uri -match 'https://www.powershellgallery.com/api/v2/package/FakeAzureModule'
+            $Uri -match 'https://www.powershellgallery.com/api/v2/package/AzureRM.FakeAzureModule'
         } -MockWith {
-            $Uri | Should be 'https://www.powershellgallery.com/api/v2/package/FakeAzureModule/2.0.0' > $null
+            $Uri | Should be 'https://www.powershellgallery.com/api/v2/package/AzureRM.FakeAzureModule/2.0.0' > $null
 
             @{
                 Headers = @{
-                    Location = 'Fake/FakeAzureModule/Content/Location.nupkg'
+                    Location = 'Fake/AzureRM.FakeAzureModule/Content/Location.nupkg'
                 }
             }
         } -Verifiable
 
         Mock New-AzureRmAutomationModule -ParameterFilter {
-            $Name -eq 'FakeAzureModule'
+            $Name -eq 'AzureRM.FakeAzureModule'
         } -MockWith {
-            $ContentLink | Should be 'Fake/FakeAzureModule/Content/Location.nupkg' > $null
+            $ContentLink | Should be 'Fake/AzureRM.FakeAzureModule/Content/Location.nupkg' > $null
         } -Verifiable
 
         Invoke-Update-AutomationAzureModulesForAccount -OptionalParameters @{
             ModuleVersionOverrides = "{
-                'FakeAzureModule' : '2.0.0'
+                'AzureRM.FakeAzureModule' : '2.0.0'
             }"
         }
 
         It 'Updates fake Azure module' {
-            Assert-MockCalled New-AzureRmAutomationModule -ParameterFilter { $Name -eq 'FakeAzureModule' } -Times 1 -Exactly
+            Assert-MockCalled New-AzureRmAutomationModule -ParameterFilter { $Name -eq 'AzureRM.FakeAzureModule' } -Times 1 -Exactly
         }
 
         Assert-VerifiableMock

--- a/Update-AutomationAzureModulesForAccount.ps1
+++ b/Update-AutomationAzureModulesForAccount.ps1
@@ -440,11 +440,11 @@ $AzModuleOnly = $false
 # restrict updates to only Az module?
 if ($AzureModuleClass -eq "Az") {
     # Import the latest version of the Az automation and accounts version to the local sandbox
-    Update-ProfileAndAutomationVersionToLatest($script:AzAutomationModuleName)
+    Update-ProfileAndAutomationVersionToLatest $script:AzAutomationModuleName
     $AzModuleOnly = $true
 } elseif ( $AzureModuleClass -eq "AzureRM") {
     # Import the latest version of the AzureRM automation and profile version to the local sandbox
-    Update-ProfileAndAutomationVersionToLatest($script:AzureRMAutomationModuleName)
+    Update-ProfileAndAutomationVersionToLatest $script:AzureRMAutomationModuleName
     $AzModuleOnly = $false
 }
 
@@ -452,7 +452,7 @@ if ($Login) {
     Login-AzureAutomation
 }
 
-$ModuleImportMapOrder = Create-ModuleImportMapOrder($AzModuleOnly)
+$ModuleImportMapOrder = Create-ModuleImportMapOrder $AzModuleOnly
 Import-ModulesInAutomationAccordingToDependency $ModuleImportMapOrder 
 
 #endregion

--- a/Update-AutomationAzureModulesForAccount.ps1
+++ b/Update-AutomationAzureModulesForAccount.ps1
@@ -311,8 +311,8 @@ function Create-ModuleImportMapOrder([bool] $AzModuleOnly) {
                                         -AutomationAccountName $AutomationAccountName |
         ?{
             ($AzModuleOnly -and ($_.Name -eq 'Az' -or $_.Name -like 'Az.*')) -or
-            (!$AzModuleOnly -and ($_.Name -eq 'AzureRM' -or $_.Name -like 'AzureRM.*')) -or
-            ($_.Name -eq 'Azure' -or $_.Name -like 'Azure.*')
+            (!$AzModuleOnly -and ($_.Name -eq 'AzureRM' -or $_.Name -like 'AzureRM.*' -or
+            $_.Name -eq 'Azure' -or $_.Name -like 'Azure.*'))
         }
 
     # Get the latest version of the AzureRM.Profile OR Az.Accounts module

--- a/Update-AutomationAzureModulesForAccount.ps1
+++ b/Update-AutomationAzureModulesForAccount.ps1
@@ -25,7 +25,7 @@ The Azure Automation account name.
 .PARAMETER AzureModuleClass
 (Optional) The class of module that will be updated (AzureRM or Az)
 If set to Az, this script will rely on only Az modules to update other modules.
-Set this to Az if your runbook contains only Az modules to avoid conflicts.
+Set this to Az if your runbooks use only Az modules to avoid conflicts.
 
 .PARAMETER AzureEnvironment
 (Optional) Azure environment name.
@@ -414,13 +414,13 @@ function Import-ModulesInAutomationAccordingToDependency([string[][]] $ModuleImp
                 # It takes some time for the modules to start getting imported.
                 # Sleep for sometime before making a query to see the status
                 Start-Sleep -Seconds 20
-                Wait-AllModulesImported $ModuleList $i $UseAzModule
+                Wait-AllModulesImported -ModuleList $ModuleList -Count $i -UseAzModule $UseAzModule
             }
         }
 
         if ($i -lt $SimultaneousModuleImportJobCount) {
             Start-Sleep -Seconds 20
-            Wait-AllModulesImported $ModuleList $i $UseAzModule
+            Wait-AllModulesImported -ModuleList $ModuleList -Count $i -UseAzModule $UseAzModule
         }
     }
 }

--- a/Update-AutomationAzureModulesForAccount.ps1
+++ b/Update-AutomationAzureModulesForAccount.ps1
@@ -323,6 +323,17 @@ function Create-ModuleImportMapOrder([bool] $AzModuleOnly) {
         # Add it to the list if the modules are not available in the same list 
         foreach ($Module in $CurrentAutomationModuleList) {
             $Name = $Module.Name
+
+            # ignore conflicting modules
+            if ($AzModuleOnly) {
+                if ($Name -eq "AzureRM" -Or $Name -Like "AzureRM.*") {
+                    continue
+                }
+            } else {
+                if ($Name -eq "Az" -Or $Name -Like "Az.*") {
+                    continue
+                }
+            }
             Write-Verbose "Checking dependencies for $Name"
             $VersionAndDependencies = Get-ModuleDependencyAndLatestVersion $Module.Name
             if ($null -eq $VersionAndDependencies) {


### PR DESCRIPTION
If the parameter AzureModuleClass is set to 'Az', the runbook will attempt to update all modules only using Az modules itself. The script takes care not to use any conflicting modules from AzureRM.

Default behavior is the same: to use AzureRM modules throughout.

issue #5 

**Note:** if for some reason you have installed both AzureRM and Az modules in your automation account, this script will still attempt to update all of them. It is perhaps desirable to present the user with a warning instead...