### PR TITLE
Cleanup undefined variables and Connect-AzAccount

### DIFF
--- a/Update-AutomationAzureModulesForAccount.ps1
+++ b/Update-AutomationAzureModulesForAccount.ps1
@@ -109,9 +109,14 @@ function Login-AzureAutomation([bool] $AzModuleOnly) {
     try {
         $RunAsConnection = Get-AutomationConnection -Name "AzureRunAsConnection"
         Write-Output "Logging in to Azure ($AzureEnvironment)..."
-
+        
+        if (!$RunAsConnection.ApplicationId) {
+            $ErrorMessage = "Connection 'AzureRunAsConnection' is incompatible type."
+            throw $ErrorMessage            
+        }
+        
         if ($AzModuleOnly) {
-            Add-AzAccount `
+            Connect-AzAccount `
                 -ServicePrincipal `
                 -TenantId $RunAsConnection.TenantId `
                 -ApplicationId $RunAsConnection.ApplicationId `
@@ -131,9 +136,9 @@ function Login-AzureAutomation([bool] $AzModuleOnly) {
         }
     } catch {
         if (!$RunAsConnection) {
-            Write-Output $servicePrincipalConnection
+            $RunAsConnection | fl | Write-Output
             Write-Output $_.Exception
-            $ErrorMessage = "Connection $connectionName not found."
+            $ErrorMessage = "Connection 'AzureRunAsConnection' not found."
             throw $ErrorMessage
         }
 


### PR DESCRIPTION
Changes made to function **Login-AzureAutomation()**:
* $servicePrincipalConnection was not defined. Corrected to $RunAsConnection.
* $connectionName was not defined. Corrected to $RunAsConnection.
* Changed **Add-AzAccount** to **Connect-AzAccount** to align with Az documentation.
* To improve user feedback, added check for $RunAsConnection.ApplicationId as some connection types do not have the ApplicationId and TenantId property and therefore fail with a "*Cannot validate argument on parameter 'Tenant'.*" error (as the TenantId is also not set in this case). 


