### PR TITLE
Force results to null array when empty

### DIFF
--- a/Update-AutomationAzureModulesForAccount.ps1
+++ b/Update-AutomationAzureModulesForAccount.ps1
@@ -213,7 +213,7 @@ function Import-AutomationModule([string] $ModuleName, [bool] $UseAzModule = $fa
     }
 
 
-    $LatestModuleVersionOnGallery = (Get-ModuleDependencyAndLatestVersion $ModuleName)[0]
+    $LatestModuleVersionOnGallery = @(Get-ModuleDependencyAndLatestVersion $ModuleName)[0]
 
     $ModuleContentUrl = Get-ModuleContentUrl $ModuleName
     # Find the actual blob storage location of the module


### PR DESCRIPTION
#27 
Get-ModuleDependencyAndLatestVersion does not return anything when !$SearchResult.

Proposed change allows script execution to continue in this instance.