### PR TITLE
Updated the script to make use of identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Import this runbook into your Automation account, and [start](https://docs.micro
   your runbooks use only Az modules to avoid conflicts. More information can be found in the
   [Microsoft Docs](https://docs.microsoft.com/azure/automation/az-modules) and
   issue [#5](https://github.com/microsoft/AzureAutomation-Account-Modules-Update/issues/5).
-* Before starting this runbook, make sure your Automation account has an [Azure Run As account credential](https://docs.microsoft.com/azure/automation/manage-runas-account) created.
+* Before starting this runbook, make sure your Automation account has an Identity created.
 * You can use this code as a regular PowerShell script instead of a runbook: just login to Azure
   using the [Connect-AzureRmAccount](https://docs.microsoft.com/powershell/module/azurerm.profile/connect-azurermaccount)
   command first, then pass `-Login $false` to the script.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Import this runbook into your Automation account, and [start](https://docs.micro
   your runbooks use only Az modules to avoid conflicts. More information can be found in the
   [Microsoft Docs](https://docs.microsoft.com/azure/automation/az-modules) and
   issue [#5](https://github.com/microsoft/AzureAutomation-Account-Modules-Update/issues/5).
-* Before starting this runbook, make sure your Automation account has an Identity created.
+* Before starting this runbook, make sure your Automation account has a System assigned Managed Identity created.
 * You can use this code as a regular PowerShell script instead of a runbook: just login to Azure
   using the [Connect-AzureRmAccount](https://docs.microsoft.com/powershell/module/azurerm.profile/connect-azurermaccount)
   command first, then pass `-Login $false` to the script.

--- a/Update-AutomationAzureModulesForAccount.ps1
+++ b/Update-AutomationAzureModulesForAccount.ps1
@@ -11,7 +11,7 @@ Update Azure PowerShell modules in an Azure Automation account.
 This Azure Automation runbook updates Azure PowerShell modules imported into an
 Azure Automation account with the module versions published to the PowerShell Gallery.
 
-Prerequisite: an Azure Automation account with Managed Identity Enabled.
+Prerequisite: an Azure Automation account with a System assigned Managed Identity Enabled.
 
 .PARAMETER ResourceGroupName
 The Azure resource group name.
@@ -126,7 +126,7 @@ function Login-AzureAutomation([bool] $AzModuleOnly) {
             # Connect to Azure with system-assigned managed identity. 
             # Please enable appropriate RBAC permissions to the system identity of this automation account. Otherwise, the runbook may fail...
             $context = (Connect-AzureRmAccount -Identity -Environment $AzureEnvironment).Context
-            Set-AzureRmContext -SubscriptionId $SubscriptionId -ErrorAction Stop
+            $AzureContext = Set-AzureRmContext -SubscriptionId $SubscriptionId -ErrorAction Stop
             Select-AzureRmSubscription -SubscriptionId $SubscriptionId  | Write-Verbose
         }
     } catch {


### PR DESCRIPTION
Since Azure Automation Run as account is getting deprecated september 30, 2023. This script is updated to make use of Identity of the automation account instead of Run As Account.

The changes have been tested to update both AzureRM and Az Modules